### PR TITLE
RenderEngine: Remove duplicate definition of PRODUCT_SHIPPING_API_LEVEL

### DIFF
--- a/libs/renderengine/gl/filters/BlurFilter.cpp
+++ b/libs/renderengine/gl/filters/BlurFilter.cpp
@@ -37,7 +37,6 @@ BlurFilter::BlurFilter(GLESRenderEngine& engine)
         mPongFbo(engine),
         mMixProgram(engine),
         mBlurProgram(engine) {
-    ALOGI("PRODUCT_SHIPPING_API_LEVEL=%d", PRODUCT_SHIPPING_API_LEVEL);
     mMixProgram.compile(getVertexShader(), getMixFragShader());
     mMPosLoc = mMixProgram.getAttributeLocation("aPosition");
     mMUvLoc = mMixProgram.getAttributeLocation("aUV");


### PR DESCRIPTION
this was defined in the device's device/common.mk, and was causing build errors, removing this definition form BlurFilter.cpp allows the build to complete